### PR TITLE
feat: display dates in localized US format with weekday

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation';
 import { MDXRemote, type MDXRemoteProps } from "next-mdx-remote/rsc";
-import { getPostBySlug, getAllPosts } from '../../../utils/posts';
+import { getPostBySlug, getAllPosts, formatDate } from '../../../utils/posts';
 import { CustomMDX } from '../../../components/mdx/MdxPage';
 
 export async function generateStaticParams() {
@@ -25,7 +25,7 @@ export default async function BlogPost({ params }: PageProps<'/blog/[slug]'>) {
         <article>
           <header className="mb-8">
             <h1 className="text-4xl font-bold mb-2">{title}</h1>
-            <time className="text-gray-600">{date}</time>
+            <time dateTime={date} className="text-gray-600">{formatDate(date)}</time>
           </header>
           
           <div className="prose prose-lg max-w-none">

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,4 +1,4 @@
-import { getAllPosts } from '../../utils/posts';
+import { getAllPosts, formatDate } from '../../utils/posts';
 
 export default async function BlogPage() {
   const blogPosts = await getAllPosts();
@@ -24,7 +24,7 @@ export default async function BlogPage() {
                   {title}
                 </a>
               </h2>
-              <time className="text-gray-600 text-sm">{date}</time>
+              <time dateTime={date} className="text-gray-600 text-sm">{formatDate(date)}</time>
               <p className="mt-4 text-gray-700">{excerpt}</p>
               <a 
                 href={`/blog/${slug}`}

--- a/src/utils/posts.test.ts
+++ b/src/utils/posts.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
-import { getAllPosts, getPostBySlug, type Post, type PostMetadata } from './posts';
+import { getAllPosts, getPostBySlug, formatDate, type Post, type PostMetadata } from './posts';
 
 // Mock fs and path modules
 jest.mock('fs');
@@ -293,6 +293,28 @@ excerpt: ${slug} excerpt
 
       expect(posts[0].metadata.slug).toBe('my-awesome-post');
       expect(posts[1].metadata.slug).toBe('another_post');
+    });
+  });
+
+  describe('formatDate', () => {
+    it('should format date in US locale with weekday', () => {
+      const result = formatDate('2024-01-20');
+      expect(result).toBe('Saturday, January 20, 2024');
+    });
+
+    it('should handle different dates correctly', () => {
+      expect(formatDate('2024-12-25')).toBe('Wednesday, December 25, 2024');
+      expect(formatDate('2023-07-04')).toBe('Tuesday, July 4, 2023');
+    });
+
+    it('should handle first day of year', () => {
+      const result = formatDate('2024-01-01');
+      expect(result).toBe('Monday, January 1, 2024');
+    });
+
+    it('should handle last day of year', () => {
+      const result = formatDate('2024-12-31');
+      expect(result).toBe('Tuesday, December 31, 2024');
     });
   });
 

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -72,3 +72,14 @@ export async function getPostBySlug(slug: string): Promise<Post> {
     content,
   };
 }
+
+export function formatDate(dateString: string): string {
+  const [year, month, day] = dateString.split('-').map(Number);
+  const date = new Date(year, month - 1, day);
+  return date.toLocaleDateString('en-US', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric'
+  });
+}


### PR DESCRIPTION
## Summary
- Add `formatDate` utility function to display dates in US locale with weekday
- Update blog list and individual post pages to use the new date format
- Dates now display as "Saturday, January 20, 2024" instead of "2024-01-20"
- Add unit tests for the new `formatDate` function

## Test plan
- [x] Unit tests pass for `formatDate` function
- [ ] Verify blog list page shows formatted dates
- [ ] Verify individual blog post pages show formatted dates
- [ ] Confirm dates display correctly across different timezones

🤖 Generated with [Claude Code](https://claude.com/claude-code)