### PR TITLE
feat: add GitHub Actions workflow for automated blog post creation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm test:*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(gh pr create:*)",
+      "Bash(python3:*)",
+      "Bash(actionlint:*)"
+    ]
+  }
+}

--- a/.github/workflows/create-blog-post.yml
+++ b/.github/workflows/create-blog-post.yml
@@ -1,0 +1,210 @@
+ name: Create Blog Post from Issue
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  create-post:
+    if: github.event.label.name == 'ready-to-post'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: init
+
+      - name: Parse issue body and create files
+        id: parse
+        uses: actions/github-script@v7
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          script: |
+            const fs = require('fs');
+            const body = context.payload.issue.body;
+
+            // Extract image URL from markdown image syntax
+            const imgMatch = body.match(/!\[screenshot\]\((.*?)\)/);
+            const imageUrl = imgMatch ? imgMatch[1] : '';
+
+            // Extract title (line after **Title:**)
+            const titleMatch = body.match(/\*\*Title:\*\*\s*\n?\s*(.+)/);
+            const title = titleMatch ? titleMatch[1].trim() : '';
+
+            // Extract content (after **Content:** until --- or end)
+            const contentMatch = body.match(/\*\*Content:\*\*\s*\n([\s\S]*?)(?=\n---|\n\*Add the|$)/);
+            const content = contentMatch ? contentMatch[1].trim() : '';
+
+            // Generate slug from title
+            const slug = title.toLowerCase()
+              .replace(/[^a-z0-9\s-]/g, '')
+              .replace(/\s+/g, '-')
+              .replace(/-+/g, '-')
+              .replace(/^-|-$/g, '');
+
+            // Get today's date in YYYY-MM-DD format
+            const date = new Date().toISOString().split('T')[0];
+
+            // Determine image extension from URL
+            const extMatch = imageUrl.match(/\.(jpg|jpeg|png|gif|webp)(?:\?|$)/i);
+            const imageExt = extMatch ? extMatch[1].toLowerCase() : 'jpeg';
+
+            console.log('Parsed values:');
+            console.log('Image URL:', imageUrl);
+            console.log('Title:', title);
+            console.log('Slug:', slug);
+            console.log('Date:', date);
+            console.log('Image Extension:', imageExt);
+            console.log('Content preview:', content.substring(0, 100) + '...');
+
+            // Validate required fields
+            if (!title) {
+              core.setFailed('Title is required. Please add a title after **Title:**');
+              return;
+            }
+            if (!content) {
+              core.setFailed('Content is required. Please add content after **Content:**');
+              return;
+            }
+            if (!imageUrl) {
+              core.setFailed('Screenshot image is required');
+              return;
+            }
+
+            // Save parsed data to a JSON file for use in later steps
+            const data = { imageUrl, title, content, slug, date, imageExt };
+            fs.writeFileSync('parsed-data.json', JSON.stringify(data, null, 2));
+
+            // Set simple outputs for step references
+            core.setOutput('slug', slug);
+            core.setOutput('title', title);
+            core.setOutput('date', date);
+            core.setOutput('image_ext', imageExt);
+            core.setOutput('image_url', imageUrl);
+
+      - name: Download image
+        run: |
+          SLUG=$(jq -r '.slug' parsed-data.json)
+          IMAGE_URL=$(jq -r '.imageUrl' parsed-data.json)
+          IMAGE_EXT=$(jq -r '.imageExt' parsed-data.json)
+
+          mkdir -p public/hkia
+          curl -L "$IMAGE_URL" -o "public/hkia/${SLUG}.${IMAGE_EXT}"
+          echo "Downloaded image to public/hkia/${SLUG}.${IMAGE_EXT}"
+
+      - name: Generate excerpt with Claude
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          TITLE=$(jq -r '.title' parsed-data.json)
+          CONTENT=$(jq -r '.content' parsed-data.json)
+
+          # Create the request payload
+          jq -n --arg title "$TITLE" --arg content "$CONTENT" '{
+            model: "claude-3-5-haiku-latest",
+            max_tokens: 100,
+            messages: [{
+              role: "user",
+              content: ("Generate a brief, engaging blog post excerpt (1-2 sentences, under 150 characters total) for a post titled \"" + $title + "\". The post content is: " + $content + ". Return ONLY the excerpt text, nothing else.")
+            }]
+          }' > request.json
+
+          RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "content-type: application/json" \
+            -d @request.json)
+
+          echo "API Response: $RESPONSE"
+
+          EXCERPT=$(echo "$RESPONSE" | jq -r '.content[0].text // "A new blog post"' | tr '\n' ' ' | head -c 150)
+
+          # Add excerpt to our data file
+          jq --arg excerpt "$EXCERPT" '.excerpt = $excerpt' parsed-data.json > temp.json && mv temp.json parsed-data.json
+
+          echo "Generated excerpt: $EXCERPT"
+
+      - name: Create MDX file
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const data = JSON.parse(fs.readFileSync('parsed-data.json', 'utf8'));
+
+            const { title, date, excerpt, slug, imageExt, content } = data;
+
+            // Escape quotes in title and excerpt for YAML frontmatter
+            const safeTitle = title.replace(/"/g, '\\"');
+            const safeExcerpt = (excerpt || 'A new blog post').replace(/"/g, '\\"');
+
+            const lines = [
+              '---',
+              'title: "' + safeTitle + '"',
+              'date: ' + date,
+              'excerpt: "' + safeExcerpt + '"',
+              '---',
+              '',
+              '![Screenshot](/hkia/' + slug + '.' + imageExt + ')',
+              '',
+              content,
+              ''
+            ];
+
+            const mdxContent = lines.join('\n');
+            const filePath = 'src/posts/' + slug + '.mdx';
+            fs.writeFileSync(filePath, mdxContent);
+            console.log('Created ' + filePath);
+            console.log('Content:');
+            console.log(mdxContent);
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        id: pr
+        with:
+          branch: post/${{ steps.parse.outputs.slug }}
+          title: "New post: ${{ steps.parse.outputs.title }}"
+          body: |
+            ## New Blog Post
+
+            **Title:** ${{ steps.parse.outputs.title }}
+            **Date:** ${{ steps.parse.outputs.date }}
+
+            ---
+
+            Closes #${{ github.event.issue.number }}
+          commit-message: "feat: add blog post - ${{ steps.parse.outputs.title }}"
+          base: init
+
+      - name: Comment and close issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = '${{ steps.pr.outputs.pull-request-number }}';
+
+            if (prNumber) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `Blog post PR created!\n\nPR: #${prNumber}`
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `Blog post files created but PR creation may have failed. Please check the Actions log.`
+              });
+            }
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              state: 'closed'
+            });


### PR DESCRIPTION
Add a workflow that converts GitHub issues (labeled `ready-to-post`) into
blog post PRs. The pipeline parses issue title/content/image, downloads
the screenshot, generates an excerpt via the Anthropic API, and creates
an MDX file with proper frontmatter. Also adds Claude Code local
permission settings for streamlined development.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>